### PR TITLE
fix: same as previous row treated as one doc

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -449,8 +449,8 @@ class ImportFile:
 			data_without_first_row = data[1:]
 			for row in data_without_first_row:
 				row_values = row.get_values(parent_column_indexes)
-				# if the row is blank, it's a child row doc
-				if all([v in INVALID_VALUES for v in row_values]):
+				# if the row is blank or same content as the previous parent row, it's a child row doc
+				if all([v in INVALID_VALUES for v in row_values]) or row_values == parent_row_values:
 					rows.append(row)
 					continue
 				# if we encounter a row which has values in parent columns,


### PR DESCRIPTION
treat repeated parent doc rows as same doc(parent), because legacy system downloaded data with inner join will normally have repeat same content for the parent docs

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
