### PR TITLE
fix: attached url with utf8 characters file name e.g Chinese

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -75,7 +75,7 @@ class File(Document):
 			self.add_comment_in_reference_doc('Attachment',
 				_('Added {0}').format("<a href='{file_url}' target='_blank'>{file_name}</a>{icon}".format(**{
 					"icon": ' <i class="fa fa-lock text-warning"></i>' if self.is_private else "",
-					"file_url": quote(self.file_url) if self.file_url else self.file_name,
+					"file_url": quote(self.file_url.encode('utf8')) if self.file_url else self.file_name,
 					"file_name": self.file_name or self.file_url
 				})))
 


### PR DESCRIPTION
treat repeated parent doc rows as same doc(parent), because legacy system downloaded data with inner join will normally have repeat same content for the parent docs

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
Currently when input doctypes with child records, empty rows in the following rows are treated as same parent doc, but normally the to-be uploaded data retrieved from legacy system with SQL statements will have repeated parent row for same parent doc, in order to fulfill the current requirements of the import template, further processing e.g via VBA is needed to empty the next rows. this pull request adds the support out of box to allow import same parent docs with repeated parent row.

e.g import one BOM except the following file is supported, 
![image](https://user-images.githubusercontent.com/12823863/109014587-3dbd2780-76ef-11eb-98d9-f83fbf008825.png)

this new format is also supported.
![image](https://user-images.githubusercontent.com/12823863/109014705-5af1f600-76ef-11eb-93dd-92a1a0033f81.png)



